### PR TITLE
Introduce platform look and feel for error messages

### DIFF
--- a/src/main/java/dev/tricht/lunaris/Lunaris.java
+++ b/src/main/java/dev/tricht/lunaris/Lunaris.java
@@ -12,6 +12,7 @@ import javafx.application.Platform;
 import lombok.extern.slf4j.Slf4j;
 import org.jnativehook.GlobalScreen;
 
+import javax.swing.*;
 import java.awt.*;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -31,6 +32,13 @@ public class Lunaris {
         Logger logger = Logger.getLogger(GlobalScreen.class.getPackage().getName());
         logger.setLevel(Level.WARNING);
         logger.setUseParentHandlers(false);
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+                | UnsupportedLookAndFeelException e) {
+            e.printStackTrace();
+            logger.warning("Could not set System Look and Feel, falling back to default.");
+        }
         new Lunaris();
     }
 


### PR DESCRIPTION
This PR will introduce a more platform specific looking alternative of the swing UI.

This is how it looks on the CrossPlatformLookAndFeel or "metallic" default:

![image](https://user-images.githubusercontent.com/9959527/72564851-fa1fa980-38b0-11ea-97a9-160cf4f3528d.png)

This is the new look on Windows 10:

![image](https://user-images.githubusercontent.com/9959527/72564894-0ad01f80-38b1-11ea-9c6d-8f515a93db8d.png)

There should be equivalent looks for different Linux distributions, on my Archlinux without anything but i3 window manager installed it fell back to the default look, no errors.