### PR TITLE
add platform independent source encoding UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <maven.compiler.target>1.9</maven.compiler.target>
         <maven.compiler.source>1.9</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
eliminates maven warnings and probably some other unwanted side effects 