### PR TITLE
Local mod resolver

### DIFF
--- a/src/main/java/dev/tricht/lunaris/com/pathofexile/itemtransformer/StatFilterSetter.java
+++ b/src/main/java/dev/tricht/lunaris/com/pathofexile/itemtransformer/StatFilterSetter.java
@@ -53,7 +53,7 @@ public class StatFilterSetter {
 
         for (AffixPart.Affix affix : itemAffixes) {
             if (affix.isCrafted()) {
-                if (item.hasLocalMods() && addTo(findAffix(affix.getText().replace(" (crafted)", "") + " (Local)", PathOfExileAPI.getCraftedAffixes()), apiAffixes)) {
+                if (affix.isLocal() && addTo(findAffix(affix.getText().replace(" (crafted)", ""), PathOfExileAPI.getCraftedAffixes()), apiAffixes)) {
                     continue;
                 }
                 if (addTo(findAffix(affix.getText().replace(" (crafted)", ""), PathOfExileAPI.getCraftedAffixes()), apiAffixes)) {
@@ -62,7 +62,7 @@ public class StatFilterSetter {
             }
 
             if (affix.isFractured()) {
-                if (item.hasLocalMods() && addTo(findAffix(affix.getText().replace(" (fractured)", "") + " (Local)", PathOfExileAPI.getFracturedAffixes()), apiAffixes)) {
+                if (affix.isLocal() && addTo(findAffix(affix.getText().replace(" (fractured)", ""), PathOfExileAPI.getFracturedAffixes()), apiAffixes)) {
                     continue;
                 }
                 if (addTo(findAffix(affix.getText().replace(" (fractured)", ""), PathOfExileAPI.getFracturedAffixes()), apiAffixes)) {
@@ -70,7 +70,7 @@ public class StatFilterSetter {
                 }
             }
 
-            if (item.hasLocalMods() && addTo(findAffix(affix.getText() + " (Local)", PathOfExileAPI.getBaseAffixes()), apiAffixes)) {
+            if (affix.isLocal() && addTo(findAffix(affix.getText(), PathOfExileAPI.getBaseAffixes()), apiAffixes)) {
                 continue;
             }
 

--- a/src/main/java/dev/tricht/lunaris/item/Item.java
+++ b/src/main/java/dev/tricht/lunaris/item/Item.java
@@ -1,10 +1,7 @@
 package dev.tricht.lunaris.item;
 
 import dev.tricht.lunaris.item.parser.AffixPart;
-import dev.tricht.lunaris.item.types.EquipmentItem;
-import dev.tricht.lunaris.item.types.EquipmentSlot;
 import dev.tricht.lunaris.item.types.ItemType;
-import dev.tricht.lunaris.item.types.WeaponItem;
 import dev.tricht.lunaris.ninja.poe.Price;
 import lombok.Data;
 
@@ -34,22 +31,4 @@ public class Item {
         return !base.equals("");
     }
 
-    public boolean hasLocalMods() {
-        if (getType() instanceof WeaponItem) {
-            return true;
-        }
-
-        if (getType() instanceof EquipmentItem) {
-            EquipmentSlot slot = ((EquipmentItem) getType()).getSlot();
-            return slot != EquipmentSlot.RING
-                    && slot != EquipmentSlot.AMULET
-                    && slot != EquipmentSlot.BELT
-                    && slot != EquipmentSlot.FLASK
-                    && slot != EquipmentSlot.JEWEL
-                    && slot != EquipmentSlot.ABYSS_JEWEL
-                    && slot != EquipmentSlot.QUIVER;
-        }
-
-        return false;
-    }
 }

--- a/src/main/java/dev/tricht/lunaris/item/ItemParser.java
+++ b/src/main/java/dev/tricht/lunaris/item/ItemParser.java
@@ -34,7 +34,7 @@ public class ItemParser {
         ItemProps itemProps = new ItemPropsParts(parts).getProps();
 
         int affixIndex = new AffixPartIndexCalculator(namePart.getRarity(), itemType, itemProps, parts).getAffixIndex();
-        AffixPart affixPart = new AffixPart(parts.get(affixIndex));
+        AffixPart affixPart = new AffixPart(parts.get(affixIndex), itemType);
 
         ImplicitPart implicitPart = new ImplicitPart(parts.get(affixIndex - 1));
         ArrayList<String> implicits = implicitPart.getImplicits();

--- a/src/main/java/dev/tricht/lunaris/item/LocalAffixResolver.java
+++ b/src/main/java/dev/tricht/lunaris/item/LocalAffixResolver.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 
 public class LocalAffixResolver {
     private final static String LOCAL = " (Local)";
-    final static List<Pattern> localArmorTypes = List.of(
+    final static List<Pattern> localArmorAffixes = List.of(
             Pattern.compile(".* to Armour"),
             Pattern.compile(".* to Evasion Rating"),
             Pattern.compile(".* to maximum Energy Shield"),
@@ -20,7 +20,7 @@ public class LocalAffixResolver {
             Pattern.compile(".* increased Armour and Energy Shield"),
             Pattern.compile(".* increased Evasion and Energy Shield"),
             Pattern.compile(".* increased increased Armour, Evasion and Energy Shield"));
-    final static List<Pattern> localWeaponTypes = List.of(
+    final static List<Pattern> localWeaponAffixes = List.of(
             Pattern.compile("Adds .* to .* Physical Damage"),
             Pattern.compile("Adds .* to .* Chaos Damage"),
             Pattern.compile("Adds .* to .* Cold Damage"),
@@ -32,9 +32,9 @@ public class LocalAffixResolver {
 
     public static String resolve(String affix, ItemType itemType) {
         if ((itemType instanceof EquipmentItem) || (itemType instanceof WeaponItem)) {
-            if (itemType instanceof EquipmentItem && localArmorTypes.stream().anyMatch(p -> p.matcher(affix).matches())) {
+            if (itemType instanceof EquipmentItem && localArmorAffixes.stream().anyMatch(p -> p.matcher(affix).matches())) {
                 return affix + LOCAL;
-            } else if (itemType instanceof  WeaponItem && localWeaponTypes.stream().anyMatch(p -> p.matcher(affix).matches())) {
+            } else if (itemType instanceof  WeaponItem && localWeaponAffixes.stream().anyMatch(p -> p.matcher(affix).matches())) {
                 return affix + LOCAL;
             }
         }

--- a/src/main/java/dev/tricht/lunaris/item/LocalAffixResolver.java
+++ b/src/main/java/dev/tricht/lunaris/item/LocalAffixResolver.java
@@ -1,0 +1,43 @@
+package dev.tricht.lunaris.item;
+
+import dev.tricht.lunaris.item.types.EquipmentItem;
+import dev.tricht.lunaris.item.types.ItemType;
+import dev.tricht.lunaris.item.types.WeaponItem;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class LocalAffixResolver {
+    private final static String LOCAL = " (Local)";
+    final static List<Pattern> localArmorTypes = List.of(
+            Pattern.compile(".* to Armour"),
+            Pattern.compile(".* to Evasion Rating"),
+            Pattern.compile(".* to maximum Energy Shield"),
+            Pattern.compile(".* increased Armour"),
+            Pattern.compile(".* increased Evasion Rating"),
+            Pattern.compile(".* increased Energy Shield"),
+            Pattern.compile(".* increased Armour and Evasion"),
+            Pattern.compile(".* increased Armour and Energy Shield"),
+            Pattern.compile(".* increased Evasion and Energy Shield"),
+            Pattern.compile(".* increased increased Armour, Evasion and Energy Shield"));
+    final static List<Pattern> localWeaponTypes = List.of(
+            Pattern.compile("Adds .* to .* Physical Damage"),
+            Pattern.compile("Adds .* to .* Chaos Damage"),
+            Pattern.compile("Adds .* to .* Cold Damage"),
+            Pattern.compile("Adds .* to .* Fire Damage"),
+            Pattern.compile("Adds .* to .* Lightning Damage"),
+            Pattern.compile(".* to Accuracy Rating"),
+            Pattern.compile(".* chance to Poison on Hit"),
+            Pattern.compile(".* increased Attack Speed"));
+
+    public static String resolve(String affix, ItemType itemType) {
+        if ((itemType instanceof EquipmentItem) || (itemType instanceof WeaponItem)) {
+            if (itemType instanceof EquipmentItem && localArmorTypes.stream().anyMatch(p -> p.matcher(affix).matches())) {
+                return affix + LOCAL;
+            } else if (itemType instanceof  WeaponItem && localWeaponTypes.stream().anyMatch(p -> p.matcher(affix).matches())) {
+                return affix + LOCAL;
+            }
+        }
+        return affix;
+    }
+}

--- a/src/main/java/dev/tricht/lunaris/item/parser/AffixPart.java
+++ b/src/main/java/dev/tricht/lunaris/item/parser/AffixPart.java
@@ -1,22 +1,25 @@
 package dev.tricht.lunaris.item.parser;
 
+import dev.tricht.lunaris.item.LocalAffixResolver;
+import dev.tricht.lunaris.item.types.ItemType;
+
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 public class AffixPart {
 
-
     private ArrayList<String> affixes;
+    private ItemType itemType;
 
-    public AffixPart(ArrayList<String> affixes) {
+    public AffixPart(ArrayList<String> affixes, ItemType itemType) {
         this.affixes = affixes;
+        this.itemType = itemType;
     }
-
 
     public ArrayList<Affix> getAffixes() {
         ArrayList<Affix> affixList = new ArrayList<>();
         for(String affix : affixes) {
-            affixList.add(new Affix(affix));
+            affixList.add(new Affix(LocalAffixResolver.resolve(affix, itemType)));
         }
 
         return affixList;
@@ -24,17 +27,26 @@ public class AffixPart {
 
     public static class Affix {
         private String affixText;
-        public Affix(String affixText){
+        private boolean isCrafted;
+        private boolean isFractured;
+        private boolean isLocal;
+
+        public Affix(String affixText) {
             this.affixText = affixText;
+            this.isCrafted = affixText.contains("(crafted)");
+            this.isFractured = affixText.contains("(fractured)");
+            this.isLocal = affixText.contains("(Local)");
         }
 
         public boolean isCrafted() {
-            return affixText.contains("(crafted)");
+            return isCrafted;
         }
 
         public boolean isFractured() {
-            return affixText.contains("(fractured)");
+            return isFractured;
         }
+
+        public boolean isLocal() { return isLocal; }
 
         public String getText() {
             return affixText;

--- a/src/test/java/dev/tricht/lunaris/com/pathofexile/itemtransformer/ItemTransformerTest.java
+++ b/src/test/java/dev/tricht/lunaris/com/pathofexile/itemtransformer/ItemTransformerTest.java
@@ -45,7 +45,7 @@ public class ItemTransformerTest {
                 "+42% to Cold Resistance\n" +
                 "+20% to Lightning Resistance\n" +
                 "30% increased Movement Speed\n" +
-                "30% increased Effect of non-Damaging Ailments on Enemies (crafted)\n" +
+                "30% increased Effect of Non-Damaging Ailments (crafted)\n" +
                 "70% increased Energy Shield (crafted)\n"));
 
         List<StatFilter> filters = query.getStats().get(0).getFilters();
@@ -57,7 +57,94 @@ public class ItemTransformerTest {
         assertStatFilter(filters.get(4), "explicit.stat_1671376347", 20); // Lightning res
         assertStatFilter(filters.get(5), "explicit.stat_2250533757", 30); // Movespeed
         assertStatFilter(filters.get(6), "crafted.stat_782230869", 30); // effect of ailments (crafted)
-        assertStatFilter(filters.get(6), "crafted.stat_782230869", 70); // %inc es (Local) crafted)
+        assertStatFilter(filters.get(7), "crafted.stat_4015621042", 70); // %inc es (Local) crafted)
+    }
+
+    @Test
+    public void testUniqueHelmetWithLocalAndGlobalMods() {
+        Query query = ItemTransformer.createQuery(parse("Rarity: Unique\n" +
+                "Devoto's Devotion\n" +
+                "Nightmare Bascinet\n" +
+                "--------\n" +
+                "Armour: 480 (augmented)\n" +
+                "Evasion Rating: 690 (augmented)\n" +
+                "--------\n" +
+                "Requirements:\n" +
+                "Level: 67\n" +
+                "Str: 62\n" +
+                "Dex: 85\n" +
+                "--------\n" +
+                "Sockets: B \n" +
+                "--------\n" +
+                "Item Level: 80\n" +
+                "--------\n" +
+                "+56 to Dexterity\n" +
+                "10% reduced Global Physical Damage\n" +
+                "16% increased Attack Speed\n" +
+                "196% increased Armour and Evasion\n" +
+                "+18% to Chaos Resistance\n" +
+                "20% increased Movement Speed\n" +
+                "Mercury Footprints\n" +
+                "--------\n" +
+                "Swift as thought are the actions of Man \n" +
+                "when borne on wings of divine providence."));
+
+        List<StatFilter> filters = query.getStats().get(0).getFilters();
+
+        assertStatFilter(filters.get(0), "explicit.stat_3261801346", 56); // Dexterity
+        assertStatFilter(filters.get(1), "explicit.stat_681332047", 16); // increased Attack Speed
+        assertStatFilter(filters.get(2), "explicit.stat_2451402625", 196); // increased Armour and Evasion (Local)
+        assertStatFilter(filters.get(3), "explicit.stat_2923486259", 18); // Chaos Resistance
+        assertStatFilter(filters.get(4), "explicit.stat_2250533757", 20); // increased Movement Speed
+        assertStatFilter(filters.get(5), "explicit.stat_3970396418"); // Mercury Footprints
+    }
+
+    @Test
+    public void testUniqueClawWithLocalAndGlobalMods() {
+        Query query = ItemTransformer.createQuery(parse("Rarity: Unique\n" +
+                "Advancing Fortress\n" +
+                "Gut Ripper\n" +
+                "--------\n" +
+                "Claw\n" +
+                "Physical Damage: 44-117 (augmented)\n" +
+                "Critical Strike Chance: 6.30%\n" +
+                "Attacks per Second: 1.50\n" +
+                "Weapon Range: 11\n" +
+                "--------\n" +
+                "Requirements:\n" +
+                "Level: 46\n" +
+                "Dex: 80\n" +
+                "Int: 80\n" +
+                "--------\n" +
+                "Sockets: G \n" +
+                "--------\n" +
+                "Item Level: 79\n" +
+                "--------\n" +
+                "+44 Life gained for each Enemy hit by Attacks (implicit)\n" +
+                "--------\n" +
+                "Socketed Gems are Supported by Level 12 Fortify\n" +
+                "15% Chance to Block Attack Damage\n" +
+                "120% increased Physical Damage\n" +
+                "+110 to Evasion Rating\n" +
+                "+35 to maximum Energy Shield\n" +
+                "+30 to maximum Life\n" +
+                "Reflects 78 Physical Damage to Melee Attackers\n" +
+                "--------\n" +
+                "\"A man cowers behind his walls.\n" +
+                "A woman carries her fortress with her.\n" +
+                "In heart, in mind, in hand.\"\n" +
+                "- Sekhema Deshret"));
+
+        List<StatFilter> filters = query.getStats().get(0).getFilters();
+
+        assertStatFilter(filters.get(0), "implicit.stat_821021828", 44); // Life gained for each Enemy hit by Attacks
+        assertStatFilter(filters.get(1), "explicit.stat_107118693", 12); // Supported by Level 12 Fortify
+        assertStatFilter(filters.get(2), "explicit.stat_2530372417", 15); // Chance to Block Attack Damage
+        assertStatFilter(filters.get(3), "explicit.stat_1509134228", 120); // increased Physical Damage (Local)
+        assertStatFilter(filters.get(4), "explicit.stat_2144192055", 110); // Evasion Rating
+        assertStatFilter(filters.get(5), "explicit.stat_3489782002", 35); // maximum Energy Shield
+        assertStatFilter(filters.get(6), "explicit.stat_3299347043", 30); // maximum Life
+        assertStatFilter(filters.get(7), "explicit.stat_3767873853", 78); // Reflects Physical Damage to Melee Attackers
     }
 
     @Test

--- a/src/test/java/dev/tricht/lunaris/com/pathofexile/itemtransformer/ModDoubleValueRangeMiddlewareTest.java
+++ b/src/test/java/dev/tricht/lunaris/com/pathofexile/itemtransformer/ModDoubleValueRangeMiddlewareTest.java
@@ -52,7 +52,7 @@ public class ModDoubleValueRangeMiddlewareTest {
                 "+42% to Cold Resistance\n" +
                 "+20% to Lightning Resistance\n" +
                 "30% increased Movement Speed\n" +
-                "30% increased Effect of non-Damaging Ailments on Enemies (crafted)\n"));
+                "30% increased Effect of Non-Damaging Ailments (crafted)\n"));
 
         List<StatFilter> filters = query.getStats().get(0).getFilters();
 

--- a/src/test/java/dev/tricht/lunaris/com/pathofexile/itemtransformer/PseudoMiddlewareTest.java
+++ b/src/test/java/dev/tricht/lunaris/com/pathofexile/itemtransformer/PseudoMiddlewareTest.java
@@ -50,7 +50,7 @@ public class PseudoMiddlewareTest {
                 "+42% to Cold Resistance\n" +
                 "+20% to Lightning Resistance\n" +
                 "30% increased Movement Speed\n" +
-                "30% increased Effect of non-Damaging Ailments on Enemies (crafted)\n"));
+                "30% increased Effect of Non-Damaging Ailments (crafted)\n"));
 
         List<StatFilter> filters = query.getStats().get(0).getFilters();
 


### PR DESCRIPTION
This moves the local mod check to the affix which solves the issue when converting to API stat filters (#82). I think it may also improve the item parser tooltip by explicitly showing which mods are local.
Major drawback is having to update the local mod list in case GGG changes it, but this can be solved later by pre-caching results from the API at startup.